### PR TITLE
feat: map-reduce batching for large dependency analysis

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,13 @@ GIT_USER_EMAIL=archbot@example.com
 # AWS_REGION=us-east-1
 # DYNAMODB_ENDPOINT_URL=http://localhost:8000
 
+# Parallelism — managed automatically by CLI (reposwarm investigate --all --parallel=N)
+# You should NOT need to set this manually. The CLI sets it for you.
+# 0 or unset = unlimited (default, good for cloud)
+# 1 = sequential (one repo at a time, recommended for <16GB RAM)
+# 2+ = N repos at a time
+# REPOSWARM_PARALLEL=0
+
 # Optional: Debug settings
 # LOG_LEVEL=DEBUG
 # PYTHONUNBUFFERED=1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## 2026-03-08 — Map-reduce batching for large dependency analysis
+
+### Problem
+
+Large repositories (e.g. quarkus with 2,215 dependency files / 13.4MB) had their dependency data truncated to 500KB to fit within Temporal's 4MB gRPC limit and Claude's 200K token context window. This meant ~96% of dependency data was lost, producing incomplete analysis for large repos.
+
+### Solution
+
+Implemented a map-reduce pattern for dependency analysis: when estimated tokens exceed a configurable threshold (default 50K), the system automatically splits dependencies into batches, analyzes each batch independently, then synthesizes all batch results into a unified dependency analysis.
+
+### Changes
+
+- **`src/investigator/core/config.py`** — Added `BATCH_TOKEN_BUDGET` (100K tokens per batch), `MIN_TOKENS_FOR_BATCHING` (50K threshold), and `INTER_BATCH_DELAY_SECONDS` (2s default) configuration constants.
+- **`src/activities/investigate_activities.py`** — Modified `read_dependencies_activity` to return `needs_batching` flag and `total_tokens_estimate` (auto-computed at runtime). Added `create_dependency_batches_activity` which loads raw deps from DynamoDB, groups by language, splits large languages into sub-batches, and saves each formatted batch to DynamoDB. Added `retrieve_batch_content_activity` to load individual batch content during the map phase.
+- **`src/workflows/investigate_single_repo_workflow.py`** — Added `_process_map_reduce_step()` method implementing the full map-reduce lifecycle (split → map → reduce). Modified `_process_analysis_steps()` to detect steps with `map_reduce` config and auto-delegate when `needs_batching=True`. Changed signature from `deps_formatted_content: str` to `deps_data: dict` for richer metadata. Added `INTER_BATCH_DELAY_SECONDS` module-level constant for rate limit mitigation between batch calls.
+- **`src/investigate_worker.py`** — Registered `create_dependency_batches_activity` and `retrieve_batch_content_activity` in the worker's activity list.
+- **`prompts/shared/dependencies_batch.md`** — New batch analysis prompt for individual dependency batches with `{batch_index}`, `{total_batches}`, `{batch_languages}` placeholders.
+- **`prompts/shared/dependencies_reduce.md`** — New synthesis prompt that combines batch analysis results into unified dependency documentation.
+- **`prompts/base_prompts.json`** — Added `map_reduce` configuration to the `dependencies` step referencing batch and reduce prompts.
+- **`src/investigator/core/claude_analyzer.py`** — Updated truncation warnings with `TRUNCATION FALLBACK` prefix for visibility.
+
+### Notes
+
+- Truncation is kept as a safety net — it guards against hard limits (gRPC 4MB, API 200K tokens) and should rarely trigger once map-reduce handles large repos.
+- Small repos (< 50K estimated tokens) are unaffected — they continue to use the existing single-pass flow.
+- For quarkus-scale repos (~38 batches), the dependencies step will make ~39 API calls (38 map + 1 reduce).
+
+---
+
 ## 2026-03-08 — Fix 4 investigation failures (rate limits, prompt overflow, gRPC payload, data_content bug)
 
 ### Problems

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 2026-03-08 — Fix 4 investigation failures (rate limits, prompt overflow, gRPC payload, data_content bug)
+
+### Problems
+
+1. **Rate limiting (429)** — camel-spring-boot-examples and argo-cd hit the Anthropic API rate limit (30K input tokens/min). The activity only retried 3 times with short backoff (5s→10s→20s), insufficient for sustained rate limits.
+2. **Prompt too long (400)** — keycloak's `module_deep_dive` step assembled 209,832 tokens, exceeding the 200K context window. No token validation existed before the API call.
+3. **gRPC payload too large** — quarkus has 2,215 dependency files totalling 13.4MB. `read_dependencies_activity` returned full file contents inline, exceeding Temporal's 4MB gRPC message limit.
+4. **`data_content` parameter mismatch** — `cache_dependencies_activity` called `save_temporary_analysis_data(data_content=...)` but the method expects `prompt_content` and `repo_structure` parameters. TypeError at runtime.
+
+### Changes
+
+- **`src/utils/dynamodb_client.py`** — Added `save_generic_data()` and `_save_chunked_generic_data()` methods for storing arbitrary JSON-serializable data with compression/chunking support. Updated `get_temporary_analysis_data()` to handle the `is_generic` flag on retrieval.
+- **`src/activities/investigation_cache.py`** — Fixed `save_dependencies()` to call `save_generic_data()` instead of the broken `save_temporary_analysis_data(data_content=...)`.
+- **`src/activities/investigate_activities.py`** — `read_dependencies_activity` now saves raw dependencies to DynamoDB inside the activity and returns only a reference key through gRPC. Added `repo_name` parameter for storage key generation. Added `formatted_content` truncation to 500KB to prevent gRPC message size limit on repos with thousands of dependency files (e.g. quarkus: 2,215 files / 6.5MB formatted).
+- **`src/workflows/investigate_single_repo_workflow.py`** — Simplified `_read_and_cache_dependencies()` (removed separate `cache_dependencies_activity` call). Increased `analyze_with_claude_context` retry policy to 6 attempts / 15s initial / 2min max. Added optional `INTER_STEP_DELAY_SECONDS` env var for inter-step throttling. Moved `os.getenv` call to module level to avoid Temporal sandbox `RestrictedWorkflowAccessError`.
+- **`src/investigator/core/config.py`** — Added `MAX_INPUT_TOKENS` (180K) and `CHARS_PER_TOKEN_ESTIMATE` (3.5) configuration constants.
+- **`src/investigator/core/claude_analyzer.py`** — Added `_estimate_tokens()` and `_truncate_to_fit()` methods for prompt truncation. Fixed truncation flow so template truncation (last resort) is always reachable — previously an early return when `previous_context` existed prevented template truncation from ever executing (caused keycloak 206K token failures). Added rate-limit-aware error handling: catches `RateLimitError`, extracts `retry-after` header, sleeps with logging before re-raising for Temporal retry.
+
+---
+
 ## 2026-03-08 — Sequential investigation mode (worker concurrency limits)
 
 ### Problem

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+## 2026-03-08 — Sequential investigation mode (worker concurrency limits)
+
+### Problem
+
+Running `reposwarm investigate --all` on resource-constrained machines (16GB RAM) caused Temporal deadlock errors (`TMPRL1101`). The worker had no concurrency limits, so all repos cloned and analyzed in parallel, saturating I/O/CPU and blocking the Temporal event loop for >2 seconds.
+
+### Solution
+
+The worker now reads `REPOSWARM_PARALLEL` from its environment to limit concurrent activities. This env var is managed automatically by the CLI's `--parallel` flag — no manual configuration needed.
+
+```
+reposwarm investigate --all --parallel=1     # CLI sets REPOSWARM_PARALLEL=1, restarts worker, runs sequentially
+```
+
+### Changes
+
+- `src/investigate_worker.py` — Reads `REPOSWARM_PARALLEL` env var. When set to a positive integer, passes `max_concurrent_activities` and `max_concurrent_workflow_task_polls` to the Temporal `Worker()` constructor. Default (unset/0) = unlimited, preserving cloud behaviour.
+- `.env.example` — Documented `REPOSWARM_PARALLEL` with note that it is managed by the CLI.
+
+### Related
+
+See `lac-reposwarm-cli` CHANGELOG for the CLI-side changes (`--parallel` flag, sequential dispatch, worker restart logic).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## 2026-03-09 — Fix map-reduce deployment issues for large repos
+
+### Problems
+
+During live testing with quarkus (2,214 dependency files, 13.4MB raw), the map-reduce pipeline failed at the batch creation stage with `'decimal.Decimal' object cannot be interpreted as an integer`. Three additional deployment issues were also discovered.
+
+### Fixes
+
+1. **DynamoDB chunked data retrieval** — boto3 returns numeric fields as `decimal.Decimal`, but Python's `range()` requires `int`. The `total_chunks` field was passed directly to `range()` in `_get_chunked_analysis_data()`, causing all chunked data retrieval to fail silently. Cast to `int()`.
+2. **Clone timeout too short** — quarkus takes ~3.5 minutes to `git clone`. The 3-minute `start_to_close_timeout` caused repeated timeouts. Bumped to 10 minutes.
+3. **Temporal SDK compatibility** — Newer Temporal SDK requires `max_concurrent_workflow_task_polls >= 2` when caching workflows. Ensured the minimum is always met.
+4. **Map-reduce never triggered** — `_read_and_cache_dependencies()` was stripping `needs_batching` and `total_tokens_estimate` from its return dict, so the map-reduce detection logic in `_process_analysis_steps()` never saw `needs_batching=True`.
+
+### Changes
+
+- **`src/utils/dynamodb_client.py`** — Cast `total_chunks` to `int` before passing to `_get_chunked_analysis_data()`.
+- **`src/workflows/investigate_single_repo_workflow.py`** — Bumped clone timeout from 3 to 10 minutes. Added `needs_batching` and `total_tokens_estimate` to the return dict from `_read_and_cache_dependencies()`.
+- **`src/investigate_worker.py`** — Ensured `max_concurrent_workflow_task_polls >= 2` regardless of `REPOSWARM_PARALLEL` setting.
+
+### Test Results
+
+Quarkus completed full investigation via map-reduce: 21 batches, 17 analysis steps, 219,326 characters of final output. No truncation needed.
+
+---
+
 ## 2026-03-08 — Map-reduce batching for large dependency analysis
 
 ### Problem

--- a/prompts/base_prompts.json
+++ b/prompts/base_prompts.json
@@ -19,7 +19,12 @@
       "description": "Analyze dependencies and external libraries",
       "context": [
         {"type": "step", "val": "hl_overview"}
-      ]
+      ],
+      "map_reduce": {
+        "batch_prompt": "../shared/dependencies_batch.md",
+        "reduce_prompt": "../shared/dependencies_reduce.md",
+        "data_source": "dependencies"
+      }
     },
     {
       "name": "core_entities",

--- a/prompts/shared/dependencies_batch.md
+++ b/prompts/shared/dependencies_batch.md
@@ -1,0 +1,32 @@
+version=1
+
+# Dependency Batch Analysis
+
+Act as a software dependency analyst. Analyze the following batch of dependency files from a software project.
+
+For each dependency found in the provided files:
+- Identify the official name (e.g. 'temporalio' becomes 'Temporal') and primary role/purpose in the project
+- Note the source file where it's defined
+- Classify as production or development dependency
+- Cite the specific file path as the source
+
+**Critical**: Only analyze dependencies explicitly present in the provided list. Do not assume or include any dependency not shown.
+
+## Repository Context
+
+This is batch {batch_index} of {total_batches} covering dependency files for this repository.
+Languages in this batch: {batch_languages}
+
+## Repository Structure (Summary)
+
+{repo_structure}
+
+---
+
+## Dependencies in This Batch
+
+**Instruction**: Analyze only the dependencies listed below.
+
+-------- LIST START ---------
+{repo_deps}
+-------- LIST END ---------

--- a/prompts/shared/dependencies_reduce.md
+++ b/prompts/shared/dependencies_reduce.md
@@ -1,0 +1,48 @@
+version=1
+
+# Dependency and Architecture Analysis — Synthesis
+
+Act as a software dependency and architecture analyst. You have been provided with dependency analyses from {total_batches} separate batches covering ALL dependency files in this repository. Your task is to synthesize these into a single, unified dependency and architecture analysis.
+
+## Objectives
+
+The purpose of this synthesis is to:
+- Provide a complete view of the internal structure and modular composition of the project.
+- Present a unified, deduplicated catalog of all external dependencies used by the project.
+
+## Instructions
+
+1. **Analyze Core Internal Modules/Packages**:
+   - Combine findings from all batches to identify the main internal modules, packages, or significant sub-components.
+   - Remove duplicates — if the same module appears in multiple batch analyses, consolidate into one entry.
+   - For each internal module or package, provide a brief description of its primary responsibility.
+
+2. **Analyze External Dependencies**:
+   - Merge all external dependencies found across all batches into a single deduplicated list.
+   - For each dependency, state its official name, primary role or purpose, and cite the source file(s) where it's referenced.
+   - **Critical**: Only include dependencies that were explicitly found in the batch analyses. Do not assume or add any dependency not mentioned.
+
+3. **Special Instruction**:
+   - Ignore any files or directories under the `arch-docs` folder.
+
+4. **Formatting**:
+   - Use clear markdown formatting for readability.
+   - Organize the output into sections with appropriate headings (e.g., "Internal Modules", "External Dependencies").
+
+## Contextual Data
+
+{previous_context}
+
+---
+
+## Repository Structure and Files
+
+{repo_structure}
+
+---
+
+## Batch Analysis Results
+
+The following contains the combined results from all {total_batches} dependency analysis batches:
+
+{repo_deps}

--- a/scripts/sync-repos-to-api.sh
+++ b/scripts/sync-repos-to-api.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Syncs repos.json into the reposwarm API server.
+# Adds any repos not already registered (they are enabled by default on add).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPOS_JSON="${1:-$SCRIPT_DIR/../prompts/repos.json}"
+
+if [[ ! -f "$REPOS_JSON" ]]; then
+  echo "Error: $REPOS_JSON not found" >&2
+  exit 1
+fi
+
+if ! command -v reposwarm &>/dev/null; then
+  echo "Error: reposwarm CLI not found in PATH" >&2
+  exit 1
+fi
+
+if ! command -v jq &>/dev/null; then
+  echo "Error: jq is required but not found" >&2
+  exit 1
+fi
+
+# Get repos already registered in the API
+existing=$(reposwarm repos list --json --for-agent 2>/dev/null | jq -r '.[].name // empty' 2>/dev/null || true)
+
+# Read repo names from repos.json
+names=$(jq -r '.repositories | keys[]' "$REPOS_JSON")
+
+added=0
+skipped=0
+failed=0
+
+for name in $names; do
+  url=$(jq -r --arg n "$name" '.repositories[$n].url' "$REPOS_JSON")
+
+  # Determine source from URL
+  if [[ "$url" == *github.com* ]]; then
+    source="GitHub"
+  else
+    source="CodeCommit"
+  fi
+
+  # Add if not already registered
+  if echo "$existing" | grep -qx "$name"; then
+    echo "  skip  $name (already registered)"
+    ((skipped++))
+  else
+    if reposwarm repos add "$name" --url "$url" --source "$source" --for-agent 2>&1; then
+      echo "  added $name"
+      ((added++))
+    else
+      echo "  FAIL  $name — could not add" >&2
+      ((failed++))
+    fi
+  fi
+done
+
+echo ""
+echo "Done: $added added, $skipped skipped, $failed failed"

--- a/src/activities/investigate_activities.py
+++ b/src/activities/investigate_activities.py
@@ -1640,15 +1640,18 @@ async def write_analysis_result_activity(temp_dir: str, repo_path: str, final_an
 
 
 @activity.defn
-async def read_dependencies_activity(repo_path: str) -> dict:
+async def read_dependencies_activity(repo_path: str, repo_name: str = None) -> dict:
     """
     Activity to read and format all dependency files from a repository.
-    
+    Raw dependencies are saved to external storage (DynamoDB) to avoid
+    exceeding Temporal's 4MB gRPC message size limit.
+
     Args:
         repo_path: Path to the cloned repository
-        
+        repo_name: Repository name (for storage key generation)
+
     Returns:
-        Dictionary with formatted dependency content ready for prompt inclusion
+        Dictionary with formatted dependency content and a reference key
     """
     activity.logger.info(f"Reading dependency files from: {repo_path}")
     
@@ -1850,20 +1853,61 @@ async def read_dependencies_activity(repo_path: str) -> dict:
         else:
             message = f"Found dependency files in {len(dependencies_by_language)} languages ({total_files} files total)"
             activity.logger.info(message)
-        
+
+        # Save raw dependencies to external storage to avoid gRPC size limits
+        deps_reference_key = None
+        if dependencies_by_language and repo_name:
+            try:
+                if os.environ.get('PROMPT_CONTEXT_STORAGE') == 'file':
+                    from utils.prompt_context import create_prompt_context_manager
+                    storage_client = create_prompt_context_manager(repo_name)
+                else:
+                    from utils.dynamodb_client import get_dynamodb_client
+                    storage_client = get_dynamodb_client()
+
+                from utils.storage_keys import KeyNameCreator
+                deps_key = KeyNameCreator.create_dependencies_key(repo_name)
+                deps_reference_key = deps_key.to_storage_key()
+
+                storage_client.save_generic_data(
+                    reference_key=deps_reference_key,
+                    data=dependencies_by_language,
+                    ttl_minutes=120
+                )
+                activity.logger.info(f"Saved raw dependencies to storage with key: {deps_reference_key}")
+            except Exception as storage_err:
+                activity.logger.warning(f"Failed to save raw dependencies to storage: {storage_err}")
+                deps_reference_key = None
+
+        # Truncate formatted_content if too large for gRPC (4MB limit)
+        # Use 500KB — full deps are saved externally, this is just for the prompt
+        MAX_FORMATTED_BYTES = 500 * 1024  # 500KB to stay well within gRPC limit
+        if len(formatted_content.encode('utf-8')) > MAX_FORMATTED_BYTES:
+            original_len = len(formatted_content)
+            formatted_content = formatted_content[:MAX_FORMATTED_BYTES]
+            formatted_content += (
+                f"\n\n... [TRUNCATED: showing first {MAX_FORMATTED_BYTES:,} bytes of "
+                f"{original_len:,} characters to fit within gRPC message size limit] ..."
+            )
+            activity.logger.warning(
+                f"Truncated formatted_content from {original_len:,} chars to fit within gRPC limit"
+            )
+
         return {
             "status": "success",
             "formatted_content": formatted_content,
-            "raw_dependencies": dependencies_by_language,
+            "raw_dependencies": {},  # Empty to avoid gRPC size limit
+            "deps_reference_key": deps_reference_key,
             "message": message
         }
-        
+
     except Exception as e:
         activity.logger.error(f"Failed to read dependencies: {str(e)}")
         return {
             "status": "error",
             "formatted_content": "Error reading dependency files!",
             "raw_dependencies": {},
+            "deps_reference_key": None,
             "message": f"Error: {str(e)}"
         }
 

--- a/src/activities/investigate_activities.py
+++ b/src/activities/investigate_activities.py
@@ -1879,6 +1879,22 @@ async def read_dependencies_activity(repo_path: str, repo_name: str = None) -> d
                 activity.logger.warning(f"Failed to save raw dependencies to storage: {storage_err}")
                 deps_reference_key = None
 
+        # Estimate tokens for batching decision
+        from investigator.core.config import Config
+        total_tokens_estimate = int(len(formatted_content) / Config.CHARS_PER_TOKEN_ESTIMATE)
+        needs_batching = total_tokens_estimate > Config.MIN_TOKENS_FOR_BATCHING
+
+        if needs_batching:
+            activity.logger.info(
+                f"Dependencies need batching: {total_tokens_estimate:,} estimated tokens "
+                f"> {Config.MIN_TOKENS_FOR_BATCHING:,} threshold ({total_files} files)"
+            )
+        else:
+            activity.logger.info(
+                f"Dependencies fit in single pass: {total_tokens_estimate:,} estimated tokens "
+                f"<= {Config.MIN_TOKENS_FOR_BATCHING:,} threshold"
+            )
+
         # Truncate formatted_content if too large for gRPC (4MB limit)
         # Use 500KB — full deps are saved externally, this is just for the prompt
         MAX_FORMATTED_BYTES = 500 * 1024  # 500KB to stay well within gRPC limit
@@ -1890,7 +1906,8 @@ async def read_dependencies_activity(repo_path: str, repo_name: str = None) -> d
                 f"{original_len:,} characters to fit within gRPC message size limit] ..."
             )
             activity.logger.warning(
-                f"Truncated formatted_content from {original_len:,} chars to fit within gRPC limit"
+                f"⚠️ TRUNCATION FALLBACK: formatted_content truncated from {original_len:,} chars. "
+                f"Map-reduce batching will handle full analysis if enabled."
             )
 
         return {
@@ -1898,6 +1915,8 @@ async def read_dependencies_activity(repo_path: str, repo_name: str = None) -> d
             "formatted_content": formatted_content,
             "raw_dependencies": {},  # Empty to avoid gRPC size limit
             "deps_reference_key": deps_reference_key,
+            "needs_batching": needs_batching,
+            "total_tokens_estimate": total_tokens_estimate,
             "message": message
         }
 
@@ -1908,6 +1927,263 @@ async def read_dependencies_activity(repo_path: str, repo_name: str = None) -> d
             "formatted_content": "Error reading dependency files!",
             "raw_dependencies": {},
             "deps_reference_key": None,
+            "needs_batching": False,
+            "total_tokens_estimate": 0,
+            "message": f"Error: {str(e)}"
+        }
+
+
+@activity.defn
+async def create_dependency_batches_activity(deps_reference_key: str, repo_name: str) -> dict:
+    """
+    Load raw dependencies from DynamoDB and split into token-budget-sized batches.
+    Each batch is formatted and saved to DynamoDB with indexed keys.
+
+    This is the 'split' phase of the map-reduce pattern for large dependency sets.
+
+    Args:
+        deps_reference_key: DynamoDB key containing the raw dependencies data
+        repo_name: Repository name for key generation
+
+    Returns:
+        Dictionary with batch metadata:
+        {
+            "status": "success",
+            "batches": [
+                {"key": "...", "languages": "Java", "files": 500, "estimated_tokens": 95000},
+                ...
+            ],
+            "total_batches": N,
+            "total_files": M
+        }
+    """
+    activity.logger.info(f"Creating dependency batches for {repo_name} from key: {deps_reference_key}")
+
+    try:
+        from investigator.core.config import Config
+
+        # Load raw dependencies from DynamoDB
+        if os.environ.get('PROMPT_CONTEXT_STORAGE') == 'file':
+            from utils.prompt_context import create_prompt_context_manager
+            storage_client = create_prompt_context_manager(repo_name)
+        else:
+            from utils.dynamodb_client import get_dynamodb_client
+            storage_client = get_dynamodb_client()
+
+        raw_deps = storage_client.get_temporary_analysis_data(deps_reference_key)
+        if not raw_deps:
+            activity.logger.error(f"No raw dependencies found for key: {deps_reference_key}")
+            return {
+                "status": "error",
+                "batches": [],
+                "total_batches": 0,
+                "total_files": 0,
+                "message": f"No dependencies found for key: {deps_reference_key}"
+            }
+
+        # Remove the reference_key that get_temporary_analysis_data adds
+        raw_deps.pop('reference_key', None)
+
+        # Build batches by language, splitting large languages if needed
+        batches = []
+        batch_token_budget = Config.BATCH_TOKEN_BUDGET
+        total_files = 0
+
+        for language in sorted(raw_deps.keys()):
+            lang_data = raw_deps[language]
+            prod_deps = lang_data.get("production_dependencies", [])
+            dev_deps = lang_data.get("developer_only_dependencies", [])
+            lang_files = len(prod_deps) + len(dev_deps)
+            total_files += lang_files
+
+            # Format the entire language to estimate tokens
+            lang_formatted = _format_dependencies_for_prompt({language: lang_data})
+            lang_tokens = int(len(lang_formatted) / Config.CHARS_PER_TOKEN_ESTIMATE)
+
+            if lang_tokens <= batch_token_budget:
+                # Language fits in one batch
+                batches.append({
+                    "languages": language,
+                    "files": lang_files,
+                    "estimated_tokens": lang_tokens,
+                    "formatted_content": lang_formatted
+                })
+                activity.logger.info(
+                    f"Batch {len(batches)}: {language} ({lang_files} files, ~{lang_tokens:,} tokens) — single batch"
+                )
+            else:
+                # Language exceeds budget — split its files into sub-batches
+                activity.logger.info(
+                    f"{language} exceeds batch budget ({lang_tokens:,} > {batch_token_budget:,} tokens). "
+                    f"Splitting {lang_files} files into sub-batches."
+                )
+                all_files = []
+                for dep in prod_deps:
+                    all_files.append(("production_dependencies", dep))
+                for dep in dev_deps:
+                    all_files.append(("developer_only_dependencies", dep))
+
+                current_batch_files = {"production_dependencies": [], "developer_only_dependencies": []}
+                current_batch_tokens = 0
+
+                for dep_type, dep_file in all_files:
+                    # Estimate tokens for this single file
+                    file_text = f"**File:** `{dep_file['full_path']}`\n```\n{dep_file['content']}\n```\n"
+                    file_tokens = int(len(file_text) / Config.CHARS_PER_TOKEN_ESTIMATE)
+
+                    if current_batch_tokens + file_tokens > batch_token_budget and (
+                        current_batch_files["production_dependencies"] or
+                        current_batch_files["developer_only_dependencies"]
+                    ):
+                        # Flush current batch
+                        batch_data = {language: current_batch_files}
+                        batch_formatted = _format_dependencies_for_prompt(batch_data)
+                        batch_file_count = (len(current_batch_files["production_dependencies"]) +
+                                          len(current_batch_files["developer_only_dependencies"]))
+                        batches.append({
+                            "languages": language,
+                            "files": batch_file_count,
+                            "estimated_tokens": current_batch_tokens,
+                            "formatted_content": batch_formatted
+                        })
+                        activity.logger.info(
+                            f"Batch {len(batches)}: {language} sub-batch ({batch_file_count} files, "
+                            f"~{current_batch_tokens:,} tokens)"
+                        )
+                        current_batch_files = {"production_dependencies": [], "developer_only_dependencies": []}
+                        current_batch_tokens = 0
+
+                    current_batch_files[dep_type].append(dep_file)
+                    current_batch_tokens += file_tokens
+
+                # Flush remaining files
+                if (current_batch_files["production_dependencies"] or
+                    current_batch_files["developer_only_dependencies"]):
+                    batch_data = {language: current_batch_files}
+                    batch_formatted = _format_dependencies_for_prompt(batch_data)
+                    batch_file_count = (len(current_batch_files["production_dependencies"]) +
+                                      len(current_batch_files["developer_only_dependencies"]))
+                    batches.append({
+                        "languages": language,
+                        "files": batch_file_count,
+                        "estimated_tokens": current_batch_tokens,
+                        "formatted_content": batch_formatted
+                    })
+                    activity.logger.info(
+                        f"Batch {len(batches)}: {language} sub-batch ({batch_file_count} files, "
+                        f"~{current_batch_tokens:,} tokens)"
+                    )
+
+        # Save each batch's formatted content to DynamoDB and collect metadata
+        batch_metadata = []
+        for idx, batch in enumerate(batches):
+            batch_key = f"_result_deps_batch_{repo_name}_{idx}"
+            try:
+                storage_client.save_generic_data(
+                    reference_key=batch_key,
+                    data=batch["formatted_content"],
+                    ttl_minutes=120
+                )
+                batch_metadata.append({
+                    "key": batch_key,
+                    "index": idx,
+                    "languages": batch["languages"],
+                    "files": batch["files"],
+                    "estimated_tokens": batch["estimated_tokens"]
+                })
+            except Exception as save_err:
+                activity.logger.error(f"Failed to save batch {idx}: {save_err}")
+                return {
+                    "status": "error",
+                    "batches": [],
+                    "total_batches": 0,
+                    "total_files": 0,
+                    "message": f"Failed to save batch {idx}: {save_err}"
+                }
+
+        activity.logger.info(
+            f"Created {len(batch_metadata)} dependency batches for {repo_name} "
+            f"covering {total_files} files"
+        )
+
+        return {
+            "status": "success",
+            "batches": batch_metadata,
+            "total_batches": len(batch_metadata),
+            "total_files": total_files,
+            "message": f"Created {len(batch_metadata)} batches from {total_files} dependency files"
+        }
+
+    except Exception as e:
+        activity.logger.error(f"Failed to create dependency batches: {str(e)}")
+        return {
+            "status": "error",
+            "batches": [],
+            "total_batches": 0,
+            "total_files": 0,
+            "message": f"Error: {str(e)}"
+        }
+
+
+@activity.defn
+async def retrieve_batch_content_activity(batch_key: str) -> dict:
+    """
+    Retrieve a single batch's formatted content from DynamoDB.
+
+    Used during the map phase of map-reduce to load each batch's
+    dependency text for injection into the batch analysis prompt.
+
+    Args:
+        batch_key: DynamoDB key for the batch content
+
+    Returns:
+        {"status": "success", "content": "..."} or error dict
+    """
+    activity.logger.info(f"Retrieving batch content for key: {batch_key}")
+
+    try:
+        if os.environ.get('PROMPT_CONTEXT_STORAGE') == 'file':
+            from utils.prompt_context import create_prompt_context_manager
+            storage_client = create_prompt_context_manager("batch")
+        else:
+            from utils.dynamodb_client import get_dynamodb_client
+            storage_client = get_dynamodb_client()
+
+        data = storage_client.get_temporary_analysis_data(batch_key)
+        if data is None:
+            activity.logger.error(f"No batch content found for key: {batch_key}")
+            return {
+                "status": "error",
+                "content": "",
+                "message": f"No batch content found for key: {batch_key}"
+            }
+
+        # Data could be a string (formatted deps text) wrapped in JSON
+        # or a dict with reference_key added by get_temporary_analysis_data
+        if isinstance(data, dict):
+            # get_temporary_analysis_data adds 'reference_key' — remove it
+            data.pop('reference_key', None)
+            # If it's a dict with a single string value, that's our content
+            # But save_generic_data stores strings as JSON strings,
+            # so json.loads returns the string directly
+            content = str(data) if data else ""
+        elif isinstance(data, str):
+            content = data
+        else:
+            content = str(data)
+
+        activity.logger.info(f"Retrieved batch content: {len(content):,} chars")
+        return {
+            "status": "success",
+            "content": content,
+            "message": f"Retrieved {len(content):,} chars"
+        }
+
+    except Exception as e:
+        activity.logger.error(f"Failed to retrieve batch content: {str(e)}")
+        return {
+            "status": "error",
+            "content": "",
             "message": f"Error: {str(e)}"
         }
 

--- a/src/activities/investigation_cache.py
+++ b/src/activities/investigation_cache.py
@@ -737,10 +737,10 @@ class InvestigationCache:
             self.logger.debug(f"   Reference key: {reference_key}")
             self.logger.debug(f"   TTL: {ttl_days} days ({ttl_minutes} minutes)")
             
-            # Save using the storage client's abstracted method
-            saved_item = self.storage_client.save_temporary_analysis_data(
+            # Save using the storage client's generic data method
+            saved_item = self.storage_client.save_generic_data(
                 reference_key=reference_key,
-                data_content=dependencies_data,
+                data=dependencies_data,
                 ttl_minutes=ttl_minutes
             )
             

--- a/src/investigate_worker.py
+++ b/src/investigate_worker.py
@@ -90,7 +90,9 @@ try:
     write_analysis_result_activity,
     cleanup_repository_activity,
     read_dependencies_activity,
-    cache_dependencies_activity
+    cache_dependencies_activity,
+    create_dependency_batches_activity,
+    retrieve_batch_content_activity
 )
     logger.info("  ✓ Imported investigate activities")
 except ImportError as e:
@@ -245,7 +247,9 @@ async def main():
             check_dynamodb_health,
             cleanup_old_health_checks,
             read_dependencies_activity,
-            cache_dependencies_activity
+            cache_dependencies_activity,
+            create_dependency_batches_activity,
+            retrieve_batch_content_activity
         ]
         logger.info(f"  Activities: {[a.__name__ for a in all_activities]}")
         

--- a/src/investigate_worker.py
+++ b/src/investigate_worker.py
@@ -249,11 +249,20 @@ async def main():
         ]
         logger.info(f"  Activities: {[a.__name__ for a in all_activities]}")
         
+        # Concurrency limits (managed by CLI via --parallel flag)
+        parallel = int(os.getenv('REPOSWARM_PARALLEL', '0'))
+        worker_kwargs = {}
+        if parallel > 0:
+            worker_kwargs['max_concurrent_activities'] = parallel
+            worker_kwargs['max_concurrent_workflow_task_polls'] = parallel
+            logger.info(f"  Concurrency limited to {parallel} (REPOSWARM_PARALLEL)")
+
         worker = Worker(
             client,
             task_queue=config['task_queue'],
             workflows=[InvestigateReposWorkflow, InvestigateSingleRepoWorkflow],
             activities=all_activities,
+            **worker_kwargs,
         )
         logger.info("✓ Worker instance created successfully!")
         

--- a/src/investigate_worker.py
+++ b/src/investigate_worker.py
@@ -258,8 +258,13 @@ async def main():
         worker_kwargs = {}
         if parallel > 0:
             worker_kwargs['max_concurrent_activities'] = parallel
-            worker_kwargs['max_concurrent_workflow_task_polls'] = parallel
+            worker_kwargs['max_concurrent_workflow_task_polls'] = max(parallel, 2)
             logger.info(f"  Concurrency limited to {parallel} (REPOSWARM_PARALLEL)")
+
+        # Newer Temporal SDK requires workflow_task_poller_behavior >= 2 when caching workflows
+        worker_kwargs['max_concurrent_workflow_task_polls'] = max(
+            worker_kwargs.get('max_concurrent_workflow_task_polls', 2), 2
+        )
 
         worker = Worker(
             client,

--- a/src/investigator/core/claude_analyzer.py
+++ b/src/investigator/core/claude_analyzer.py
@@ -94,27 +94,124 @@ class ClaudeAnalyzer:
             # No version line found, return as-is
             return prompt_template
     
-    def analyze_with_context(self, prompt_template: str, repo_structure: str, 
+    def _estimate_tokens(self, text: str) -> int:
+        """Estimate token count from character count using a conservative ratio."""
+        if not text:
+            return 0
+        return int(len(text) / Config.CHARS_PER_TOKEN_ESTIMATE)
+
+    def _truncate_to_fit(self, template: str, repo_structure: str,
+                         previous_context: Optional[str]) -> tuple:
+        """
+        Truncate inputs if estimated token count exceeds MAX_INPUT_TOKENS.
+
+        Truncation priority (most expendable first):
+        1. repo_structure — usually the largest component, can be partially shown
+        2. previous_context — helpful but not essential
+        3. template — never truncated (this is the instruction)
+
+        Returns:
+            Tuple of (template, repo_structure, previous_context)
+        """
+        max_input = Config.MAX_INPUT_TOKENS
+        template_tokens = self._estimate_tokens(template)
+        structure_tokens = self._estimate_tokens(repo_structure)
+        context_tokens = self._estimate_tokens(previous_context) if previous_context else 0
+        total_tokens = template_tokens + structure_tokens + context_tokens
+
+        if total_tokens <= max_input:
+            return template, repo_structure, previous_context
+
+        tokens_to_remove = total_tokens - max_input
+        self.logger.warning(
+            f"⚠️ Estimated {total_tokens:,} input tokens exceeds limit of {max_input:,}. "
+            f"Template: {template_tokens:,}, Structure: {structure_tokens:,}, Context: {context_tokens:,}. "
+            f"Need to remove ~{tokens_to_remove:,} tokens."
+        )
+
+        # Try truncating repo_structure first
+        if structure_tokens > tokens_to_remove:
+            max_chars = int((structure_tokens - tokens_to_remove) * Config.CHARS_PER_TOKEN_ESTIMATE)
+            truncated = repo_structure[:max_chars]
+            truncated += (
+                f"\n\n... [TRUNCATED: showing first {max_chars:,} of "
+                f"{len(repo_structure):,} characters to fit within {max_input:,} token limit] ..."
+            )
+            self.logger.warning(
+                f"Truncated repo_structure from {len(repo_structure):,} to {len(truncated):,} chars"
+            )
+            return template, truncated, previous_context
+
+        # Drop context if present
+        if previous_context:
+            self.logger.warning("Removing previous_context entirely to fit within token limit")
+            previous_context = None
+            tokens_to_remove -= context_tokens
+            context_tokens = 0
+
+            if tokens_to_remove <= 0:
+                # Dropping context alone is sufficient
+                return template, repo_structure, None
+
+        # Truncate structure aggressively
+        remaining_for_structure = max(max_input - template_tokens, 0)
+        max_chars = int(remaining_for_structure * Config.CHARS_PER_TOKEN_ESTIMATE)
+        max_chars = max(max_chars, 1000)  # Keep at least 1000 chars
+        truncated = repo_structure[:max_chars]
+        truncated += "\n\n... [TRUNCATED] ..."
+        self.logger.warning(
+            f"Truncated repo_structure from {len(repo_structure):,} to {len(truncated):,} chars"
+            f"{' (also removed previous_context)' if context_tokens == 0 else ''}"
+        )
+
+        # If template alone still exceeds limit, truncate the template as a last resort
+        if template_tokens > max_input:
+            self.logger.warning(
+                f"⚠️ Template alone ({template_tokens:,} tokens) exceeds limit ({max_input:,}). "
+                f"Truncating template as last resort."
+            )
+            # Reserve tokens for structure placeholder and response overhead
+            reserved_tokens = 2000
+            max_template_chars = int((max_input - reserved_tokens) * Config.CHARS_PER_TOKEN_ESTIMATE)
+            max_template_chars = max(max_template_chars, 10000)  # Keep at least 10K chars
+            template = template[:max_template_chars]
+            template += (
+                f"\n\n... [TEMPLATE TRUNCATED: showing first {max_template_chars:,} of "
+                f"{int(template_tokens * Config.CHARS_PER_TOKEN_ESTIMATE):,} characters "
+                f"to fit within {max_input:,} token limit] ..."
+            )
+            self.logger.warning(
+                f"Truncated template to {max_template_chars:,} chars"
+            )
+
+        return template, truncated, None
+
+    def analyze_with_context(self, prompt_template: str, repo_structure: str,
                            previous_context: Optional[str] = None,
                            config_overrides: Optional[dict] = None) -> str:
         """
         Analyze using Claude with optional context from previous analyses.
-        
+
         Args:
             prompt_template: Prompt template to use
             repo_structure: Repository structure string
             previous_context: Previous analysis results to include as context
             config_overrides: Optional dict with claude_model, max_tokens overrides
-            
+
         Returns:
             Analysis result from Claude
         """
         if config_overrides is None:
             config_overrides = {}
-        
+
         # Clean the prompt template first (remove version lines, etc.)
         cleaned_template = self.clean_prompt(prompt_template)
-        
+
+        # Validate and truncate if estimated tokens exceed the context window
+        cleaned_template, repo_structure, previous_context = self._truncate_to_fit(
+            cleaned_template, repo_structure, previous_context
+        )
+
         # Replace placeholders in the cleaned prompt
         prompt = cleaned_template.replace("{repo_structure}", repo_structure)
         
@@ -153,8 +250,38 @@ class ClaudeAnalyzer:
             return analysis_text
             
         except Exception as e:
-            self.logger.error(f"Claude API request failed: {str(e)}")
-            raise Exception(f"Failed to get analysis from Claude: {str(e)}")
+            error_str = str(e)
+
+            # Check for rate limit errors — sleep before re-raising so Temporal
+            # retries after the rate limit window has passed
+            try:
+                from anthropic import RateLimitError
+                if isinstance(e, RateLimitError):
+                    retry_after = None
+                    if hasattr(e, 'response') and e.response is not None:
+                        retry_after = e.response.headers.get('retry-after')
+
+                    if retry_after:
+                        try:
+                            wait_seconds = min(int(retry_after), 120)
+                        except (ValueError, TypeError):
+                            wait_seconds = 30
+                    else:
+                        wait_seconds = 30
+
+                    self.logger.warning(
+                        f"⚠️ Rate limited (429). Sleeping {wait_seconds}s before retry "
+                        f"(retry-after: {retry_after})"
+                    )
+                    import time
+                    time.sleep(wait_seconds)
+                    self.logger.info(f"Rate limit backoff complete ({wait_seconds}s), re-raising for Temporal retry")
+                    raise Exception(f"Rate limited by Claude API (slept {wait_seconds}s): {error_str}")
+            except ImportError:
+                pass  # anthropic not available, fall through to generic handling
+
+            self.logger.error(f"Claude API request failed: {error_str}")
+            raise Exception(f"Failed to get analysis from Claude: {error_str}")
     
     def analyze_structure(self, repo_structure: str, prompt_template: str) -> str:
         """

--- a/src/investigator/core/claude_analyzer.py
+++ b/src/investigator/core/claude_analyzer.py
@@ -138,7 +138,8 @@ class ClaudeAnalyzer:
                 f"{len(repo_structure):,} characters to fit within {max_input:,} token limit] ..."
             )
             self.logger.warning(
-                f"Truncated repo_structure from {len(repo_structure):,} to {len(truncated):,} chars"
+                f"⚠️ TRUNCATION FALLBACK: repo_structure truncated from {len(repo_structure):,} to "
+                f"{len(truncated):,} chars. Consider adding map-reduce support for this step."
             )
             return template, truncated, previous_context
 

--- a/src/investigator/core/config.py
+++ b/src/investigator/core/config.py
@@ -17,6 +17,14 @@ class Config:
     MAX_INPUT_TOKENS = int(os.getenv('MAX_INPUT_TOKENS', '180000'))
     CHARS_PER_TOKEN_ESTIMATE = float(os.getenv('CHARS_PER_TOKEN_ESTIMATE', '3.5'))
 
+    # Map-reduce batching for large analysis steps (e.g. dependencies)
+    # Token budget per batch — leave room for template + repo_structure in 180K window
+    BATCH_TOKEN_BUDGET = int(os.getenv('BATCH_TOKEN_BUDGET', '100000'))
+    # Minimum estimated tokens before batching kicks in (don't batch small deps)
+    MIN_TOKENS_FOR_BATCHING = int(os.getenv('MIN_TOKENS_FOR_BATCHING', '50000'))
+    # Delay between batch API calls to mitigate rate limits (seconds)
+    INTER_BATCH_DELAY_SECONDS = float(os.getenv('INTER_BATCH_DELAY_SECONDS', '2'))
+
     # Valid Claude model names for validation (4.x models only)
     # See: https://platform.claude.com/docs/en/about-claude/models/overview
     VALID_CLAUDE_MODELS = [

--- a/src/investigator/core/config.py
+++ b/src/investigator/core/config.py
@@ -11,7 +11,12 @@ class Config:
     # Claude API settings - read from env, with sensible defaults
     CLAUDE_MODEL = os.getenv('ANTHROPIC_MODEL') or os.getenv('CLAUDE_MODEL') or "claude-sonnet-4-6-20260120"
     MAX_TOKENS = int(os.getenv('MAX_TOKENS', '6000'))
-    
+
+    # Input token limits — truncate prompts that would exceed the context window
+    # 180K leaves room for output tokens within the 200K context window
+    MAX_INPUT_TOKENS = int(os.getenv('MAX_INPUT_TOKENS', '180000'))
+    CHARS_PER_TOKEN_ESTIMATE = float(os.getenv('CHARS_PER_TOKEN_ESTIMATE', '3.5'))
+
     # Valid Claude model names for validation (4.x models only)
     # See: https://platform.claude.com/docs/en/about-claude/models/overview
     VALID_CLAUDE_MODELS = [

--- a/src/utils/dynamodb_client.py
+++ b/src/utils/dynamodb_client.py
@@ -781,7 +781,7 @@ class DynamoDBClient:
                 
                 # Check if data is chunked
                 if item.get('is_chunked', False):
-                    return self._get_chunked_analysis_data(reference_key, item.get('total_chunks', 0))
+                    return self._get_chunked_analysis_data(reference_key, int(item.get('total_chunks', 0)))
                 
                 # Check if data is compressed
                 if item.get('is_compressed', False):

--- a/src/utils/dynamodb_client.py
+++ b/src/utils/dynamodb_client.py
@@ -439,9 +439,171 @@ class DynamoDBClient:
             logger.error(f"Error saving temporary analysis data to DynamoDB: {e}")
             raise
     
-    def _save_chunked_analysis_data(self, reference_key: str, prompt_content: str, 
+    def save_generic_data(self,
+                         reference_key: str,
+                         data: Any,
+                         ttl_minutes: int = 60) -> Dict[str, Any]:
+        """
+        Save arbitrary JSON-serializable data to DynamoDB with TTL.
+        Handles compression and chunking for large payloads.
+
+        Unlike save_temporary_analysis_data (which expects prompt_content/repo_structure),
+        this method stores any JSON-serializable data (dicts, lists, strings, etc.).
+
+        Args:
+            reference_key: Unique reference key for retrieval
+            data: Any JSON-serializable data (dict, list, str, etc.)
+            ttl_minutes: TTL in minutes (default 60)
+
+        Returns:
+            Dictionary with save status
+        """
+        try:
+            import gzip
+            import base64
+            import json
+
+            current_timestamp = int(datetime.now(timezone.utc).timestamp())
+            ttl_timestamp = current_timestamp + (ttl_minutes * 60)
+
+            # Serialize data to JSON
+            data_json = json.dumps(data)
+            data_size = len(data_json.encode('utf-8'))
+
+            logger.info(f"Saving generic data ({data_size} bytes) with key: {reference_key}")
+
+            if data_size > 300 * 1024:  # 300KB threshold
+                logger.info(f"Large generic data detected ({data_size} bytes), compressing...")
+
+                compressed_data = gzip.compress(data_json.encode('utf-8'))
+                compressed_b64 = base64.b64encode(compressed_data).decode('utf-8')
+                compressed_size = len(compressed_b64)
+
+                logger.info(f"Compressed from {data_size} to {compressed_size} bytes (ratio: {compressed_size/data_size:.2%})")
+
+                if compressed_size > 380 * 1024:
+                    # Use chunking for very large data
+                    return self._save_chunked_generic_data(
+                        reference_key, data_json, ttl_minutes,
+                        current_timestamp, ttl_timestamp
+                    )
+
+                # Save compressed
+                item = {
+                    'repository_name': f"_temp_{reference_key}",
+                    'analysis_timestamp': current_timestamp,
+                    'analysis_type': 'temporary_analysis_data',
+                    'reference_key': reference_key,
+                    'compressed_data': compressed_b64,
+                    'is_compressed': True,
+                    'is_generic': True,
+                    'original_size': data_size,
+                    'compressed_size': compressed_size,
+                    'ttl_timestamp': ttl_timestamp,
+                    'created_at': datetime.now(timezone.utc).isoformat()
+                }
+            else:
+                # Small enough to save as-is
+                item = {
+                    'repository_name': f"_temp_{reference_key}",
+                    'analysis_timestamp': current_timestamp,
+                    'analysis_type': 'temporary_analysis_data',
+                    'reference_key': reference_key,
+                    'generic_data': data_json,
+                    'is_compressed': False,
+                    'is_generic': True,
+                    'ttl_timestamp': ttl_timestamp,
+                    'created_at': datetime.now(timezone.utc).isoformat()
+                }
+
+            item = self._convert_floats_to_decimal(item)
+            self.table.put_item(Item=item)
+
+            logger.info(f"Saved generic data with reference key: {reference_key}")
+            return {
+                "status": "success",
+                "reference_key": reference_key,
+                "ttl_minutes": ttl_minutes,
+                "is_compressed": item.get('is_compressed', False)
+            }
+
+        except ClientError as e:
+            logger.error(f"Error saving generic data to DynamoDB: {e}")
+            raise
+
+    def _save_chunked_generic_data(self, reference_key: str, data_json: str,
+                                   ttl_minutes: int, current_timestamp: int,
+                                   ttl_timestamp: int) -> Dict[str, Any]:
+        """
+        Save generic data in chunks when it's too large even after compression.
+        """
+        import gzip
+        import base64
+
+        logger.info(f"Generic data too large even after compression, using chunking for: {reference_key}")
+
+        compressed_data = gzip.compress(data_json.encode('utf-8'))
+        compressed_b64 = base64.b64encode(compressed_data).decode('utf-8')
+
+        chunk_size = 350 * 1024
+        total_size = len(compressed_b64)
+        total_chunks = (total_size + chunk_size - 1) // chunk_size
+
+        logger.info(f"Splitting {total_size} bytes into {total_chunks} chunks")
+
+        try:
+            # Save metadata item
+            metadata_item = {
+                'repository_name': f"_temp_{reference_key}",
+                'analysis_timestamp': current_timestamp,
+                'analysis_type': 'temporary_analysis_data',
+                'reference_key': reference_key,
+                'is_chunked': True,
+                'is_generic': True,
+                'total_chunks': total_chunks,
+                'total_size': total_size,
+                'ttl_timestamp': ttl_timestamp,
+                'created_at': datetime.now(timezone.utc).isoformat()
+            }
+            metadata_item = self._convert_floats_to_decimal(metadata_item)
+            self.table.put_item(Item=metadata_item)
+
+            for i in range(total_chunks):
+                start_idx = i * chunk_size
+                end_idx = min((i + 1) * chunk_size, total_size)
+                chunk_data = compressed_b64[start_idx:end_idx]
+
+                chunk_item = {
+                    'repository_name': f"_temp_{reference_key}_chunk_{i}",
+                    'analysis_timestamp': current_timestamp,
+                    'analysis_type': 'temporary_analysis_chunk',
+                    'reference_key': reference_key,
+                    'chunk_index': i,
+                    'chunk_data': chunk_data,
+                    'ttl_timestamp': ttl_timestamp,
+                    'created_at': datetime.now(timezone.utc).isoformat()
+                }
+                chunk_item = self._convert_floats_to_decimal(chunk_item)
+                self.table.put_item(Item=chunk_item)
+
+                logger.debug(f"Saved generic chunk {i+1}/{total_chunks} for {reference_key}")
+
+            logger.info(f"Successfully saved {total_chunks} generic chunks for reference key: {reference_key}")
+            return {
+                "status": "success",
+                "reference_key": reference_key,
+                "ttl_minutes": ttl_minutes,
+                "is_chunked": True,
+                "total_chunks": total_chunks
+            }
+
+        except ClientError as e:
+            logger.error(f"Error saving chunked generic data to DynamoDB: {e}")
+            raise
+
+    def _save_chunked_analysis_data(self, reference_key: str, prompt_content: str,
                                    repo_structure: str, context: Optional[str],
-                                   ttl_minutes: int, current_timestamp: int, 
+                                   ttl_minutes: int, current_timestamp: int,
                                    ttl_timestamp: int) -> Dict[str, Any]:
         """
         Save analysis data in chunks when it's too large even after compression.
@@ -578,9 +740,10 @@ class DynamoDBClient:
             data = json.loads(decompressed_json)
             
             logger.info(f"Successfully retrieved and reassembled {total_chunks} chunks for {reference_key}")
-            data['reference_key'] = reference_key
+            if isinstance(data, dict):
+                data['reference_key'] = reference_key
             return data
-            
+
         except Exception as e:
             logger.error(f"Error retrieving chunked data from DynamoDB: {e}")
             return None
@@ -634,12 +797,26 @@ class DynamoDBClient:
                         data = json.loads(decompressed_json)
                         
                         logger.info(f"Retrieved and decompressed temporary analysis data for reference key: {reference_key}")
-                        data['reference_key'] = reference_key
+                        if isinstance(data, dict):
+                            data['reference_key'] = reference_key
                         return data
                     else:
                         logger.error(f"Compressed data flag set but no compressed_data found for: {reference_key}")
                         return None
                 
+                # Check if this is generic data (stored via save_generic_data)
+                if item.get('is_generic', False):
+                    import json
+                    generic_data = item.get('generic_data')
+                    if generic_data:
+                        data = json.loads(generic_data) if isinstance(generic_data, str) else generic_data
+                        if isinstance(data, dict):
+                            data['reference_key'] = reference_key
+                        return data
+                    else:
+                        logger.error(f"Generic data flag set but no generic_data found for: {reference_key}")
+                        return None
+
                 # Regular uncompressed data - convert and return
                 return self._convert_decimal_to_float(item)
             

--- a/src/workflows/investigate_single_repo_workflow.py
+++ b/src/workflows/investigate_single_repo_workflow.py
@@ -6,8 +6,12 @@ from temporalio import workflow
 from temporalio.common import RetryPolicy
 from datetime import timedelta, datetime
 from typing import Dict, Optional
+import asyncio
 import logging
 import uuid
+
+# Read at module level to avoid Temporal sandbox restrictions on os.getenv inside workflows
+INTER_STEP_DELAY_SECONDS = float(os.getenv('INTER_STEP_DELAY_SECONDS', '0'))
 
 from activities.investigate_activities import (
     save_to_arch_hub,
@@ -226,11 +230,12 @@ class InvestigateSingleRepoWorkflow:
         self._last_heartbeat = workflow.now()
         
         logger.info(f"Reading and caching dependencies for repository at: {repo_path}")
-        
-        # Read and format dependencies
+
+        # Read, format, and cache dependencies (caching now happens inside the activity
+        # to avoid sending large payloads through Temporal's gRPC which has a 4MB limit)
         deps_data = await workflow.execute_activity(
             read_dependencies_activity,
-            args=[repo_path],
+            args=[repo_path, self._repo_name],
             start_to_close_timeout=timedelta(minutes=2),
             retry_policy=RetryPolicy(
                 maximum_attempts=2,
@@ -238,41 +243,20 @@ class InvestigateSingleRepoWorkflow:
                 maximum_interval=timedelta(seconds=10),
             ),
         )
-        
+
         if deps_data["status"] != "success":
             logger.warning(f"Failed to read dependencies: {deps_data.get('message', 'Unknown error')}")
             return {
                 "deps_reference_key": None,
                 "formatted_content": "Error reading dependency files!"
             }
-        
-        logger.info(f"Dependencies read successfully: {deps_data['message']}")
-        
-        # Cache the dependencies data if we found any
-        if deps_data["raw_dependencies"]:
-            cache_result = await workflow.execute_activity(
-                cache_dependencies_activity,
-                args=[self._repo_name, deps_data["raw_dependencies"]],
-                start_to_close_timeout=timedelta(minutes=2),
-                retry_policy=RetryPolicy(
-                    maximum_attempts=2,
-                    initial_interval=timedelta(seconds=2),
-                    maximum_interval=timedelta(seconds=10),
-                ),
-            )
-            
-            if cache_result["status"] == "success":
-                logger.info(f"Dependencies cached successfully with key: {cache_result['deps_reference_key']}")
-                return {
-                    "deps_reference_key": cache_result["deps_reference_key"],
-                    "formatted_content": deps_data["formatted_content"]
-                }
-            else:
-                logger.warning(f"Failed to cache dependencies: {cache_result.get('error', 'Unknown error')}")
-        
-        # Return formatted content even if caching failed or no dependencies found
+
+        deps_reference_key = deps_data.get("deps_reference_key")
+        logger.info(f"Dependencies read successfully: {deps_data['message']}"
+                     f"{f', cached with key: {deps_reference_key}' if deps_reference_key else ''}")
+
         return {
-            "deps_reference_key": None,
+            "deps_reference_key": deps_reference_key,
             "formatted_content": deps_data["formatted_content"]
         }
 
@@ -398,9 +382,9 @@ class InvestigateSingleRepoWorkflow:
                 args=[claude_input],
                 start_to_close_timeout=timedelta(minutes=15),
                 retry_policy=RetryPolicy(
-                    maximum_attempts=3,
-                    initial_interval=timedelta(seconds=5),
-                    maximum_interval=timedelta(seconds=30),
+                    maximum_attempts=6,
+                    initial_interval=timedelta(seconds=15),
+                    maximum_interval=timedelta(minutes=2),
                     backoff_coefficient=2.0
                 ),
             )
@@ -436,7 +420,12 @@ class InvestigateSingleRepoWorkflow:
             )
             
             logger.info(f"Step {step_name} completed with result key: {result_key}")
-        
+
+            # Optional inter-step delay to mitigate API rate limits
+            if INTER_STEP_DELAY_SECONDS > 0:
+                logger.info(f"⏳ Rate limit mitigation: waiting {INTER_STEP_DELAY_SECONDS}s before next step")
+                await asyncio.sleep(INTER_STEP_DELAY_SECONDS)
+
         # Retrieve all results from DynamoDB for final processing
         logger.info(f"Retrieving all {len(step_results)} results from DynamoDB")
         

--- a/src/workflows/investigate_single_repo_workflow.py
+++ b/src/workflows/investigate_single_repo_workflow.py
@@ -12,11 +12,12 @@ import uuid
 
 # Read at module level to avoid Temporal sandbox restrictions on os.getenv inside workflows
 INTER_STEP_DELAY_SECONDS = float(os.getenv('INTER_STEP_DELAY_SECONDS', '0'))
+INTER_BATCH_DELAY_SECONDS = float(os.getenv('INTER_BATCH_DELAY_SECONDS', '2'))
 
 from activities.investigate_activities import (
     save_to_arch_hub,
     clone_repository_activity,
-    analyze_repository_structure_activity, 
+    analyze_repository_structure_activity,
     get_prompts_config_activity,
     read_prompt_file_activity,
     save_prompt_context_activity,
@@ -25,7 +26,9 @@ from activities.investigate_activities import (
     write_analysis_result_activity,
     cleanup_repository_activity,
     read_dependencies_activity,
-    cache_dependencies_activity
+    cache_dependencies_activity,
+    create_dependency_batches_activity,
+    retrieve_batch_content_activity
 )
 from activities.investigation_cache_activities import (
     check_if_repo_needs_investigation,
@@ -260,16 +263,299 @@ class InvestigateSingleRepoWorkflow:
             "formatted_content": deps_data["formatted_content"]
         }
 
-    async def _process_analysis_steps(self, processing_order: list, prompts_dir: str, repo_structure: Dict, config_overrides: ConfigOverrides = None, deps_formatted_content: str = None) -> ProcessAnalysisResult:
-        """Process each analysis step using PromptContext for cleaner abstraction."""
+    async def _process_map_reduce_step(self, step: dict, prompts_dir: str,
+                                       repo_structure: Dict, config_overrides: ConfigOverrides,
+                                       deps_data: dict, step_results: dict) -> str:
+        """
+        Process a step using map-reduce pattern for large datasets.
+
+        1. Create batches from the data source (split)
+        2. Analyze each batch with the batch prompt (map)
+        3. Synthesize all batch results with the reduce prompt (reduce)
+
+        Args:
+            step: Step configuration from base_prompts.json (includes map_reduce config)
+            prompts_dir: Directory containing prompt files
+            repo_structure: Repository structure dict
+            config_overrides: Claude config overrides
+            deps_data: Dependencies data dict (from _read_and_cache_dependencies)
+            step_results: Current step results dict for context chaining
+
+        Returns:
+            result_key for the final synthesized result
+        """
+        step_name = step.get("name", "unknown")
+        map_reduce_config = step["map_reduce"]
+        context_config = step.get("context", None)
+        deps_reference_key = deps_data.get("deps_reference_key")
+        latest_commit = getattr(self, '_latest_commit', None)
+
+        logger.info(f"🗺️ Starting map-reduce for step: {step_name}")
+
+        # === SPLIT PHASE ===
+        logger.info(f"📦 Split phase: creating batches from deps_reference_key={deps_reference_key}")
+        batches_result = await workflow.execute_activity(
+            create_dependency_batches_activity,
+            args=[deps_reference_key, self._repo_name],
+            start_to_close_timeout=timedelta(minutes=5),
+            retry_policy=RetryPolicy(
+                maximum_attempts=2,
+                initial_interval=timedelta(seconds=5),
+                maximum_interval=timedelta(seconds=30),
+            ),
+        )
+
+        if batches_result["status"] != "success":
+            raise Exception(f"Failed to create dependency batches: {batches_result.get('message')}")
+
+        batches = batches_result["batches"]
+        total_batches = batches_result["total_batches"]
+        logger.info(f"📦 Split phase complete: {total_batches} batches, {batches_result['total_files']} files")
+
+        # === MAP PHASE ===
+        logger.info(f"🗺️ Map phase: analyzing {total_batches} batches")
+        batch_result_keys = []
+
+        # Read the batch prompt template
+        batch_prompt_file = map_reduce_config["batch_prompt"]
+        batch_prompt_result = await workflow.execute_activity(
+            read_prompt_file_activity,
+            args=[prompts_dir, batch_prompt_file],
+            start_to_close_timeout=timedelta(minutes=2),
+            retry_policy=RetryPolicy(
+                maximum_attempts=2,
+                initial_interval=timedelta(seconds=1),
+                maximum_interval=timedelta(seconds=10),
+            ),
+        )
+
+        if batch_prompt_result["status"] == "not_found":
+            raise Exception(f"Batch prompt file not found: {batch_prompt_file}")
+
+        batch_prompt_template = batch_prompt_result["prompt_content"]
+        batch_prompt_version = batch_prompt_result.get("prompt_version", "1")
+
+        for batch_idx, batch_info in enumerate(batches):
+            batch_key = batch_info["key"]
+            batch_languages = batch_info["languages"]
+            batch_files = batch_info["files"]
+
+            logger.info(
+                f"🗺️ Map batch {batch_idx + 1}/{total_batches}: "
+                f"{batch_languages} ({batch_files} files, ~{batch_info['estimated_tokens']:,} tokens)"
+            )
+
+            # Customize the batch prompt with batch-specific placeholders
+            customized_prompt = batch_prompt_template
+            customized_prompt = customized_prompt.replace("{batch_index}", str(batch_idx + 1))
+            customized_prompt = customized_prompt.replace("{total_batches}", str(total_batches))
+            customized_prompt = customized_prompt.replace("{batch_languages}", batch_languages)
+
+            # Create context for this batch analysis
+            batch_step_name = f"{step_name}_batch_{batch_idx}"
+            batch_context_dict = {
+                "repo_name": self._repo_name,
+                "step_name": batch_step_name,
+                "prompt_version": batch_prompt_version,
+                "context_reference_keys": []
+            }
+
+            # Load the batch content from DynamoDB and inject as deps
+            # The batch content was saved as a string by create_dependency_batches_activity
+            # We pass it as deps_formatted_content so save_prompt_context_activity injects it
+            # into {repo_deps} placeholder
+
+            # Retrieve batch content from storage
+            batch_content_result = await workflow.execute_activity(
+                retrieve_batch_content_activity,
+                args=[batch_key],
+                start_to_close_timeout=timedelta(minutes=2),
+                retry_policy=RetryPolicy(
+                    maximum_attempts=2,
+                    initial_interval=timedelta(seconds=2),
+                    maximum_interval=timedelta(seconds=10),
+                ),
+            )
+
+            if batch_content_result.get("status") != "success":
+                raise Exception(f"Failed to retrieve batch {batch_idx} content: {batch_content_result.get('message')}")
+
+            batch_content = batch_content_result["content"]
+
+            # Save batch prompt data
+            save_result = await workflow.execute_activity(
+                save_prompt_context_activity,
+                args=[batch_context_dict, customized_prompt, repo_structure, batch_content],
+                start_to_close_timeout=timedelta(minutes=2),
+                retry_policy=RetryPolicy(
+                    maximum_attempts=2,
+                    initial_interval=timedelta(seconds=1),
+                    maximum_interval=timedelta(seconds=10),
+                ),
+            )
+
+            if save_result["status"] != "success":
+                raise Exception(f"Failed to save batch {batch_idx} prompt context")
+
+            updated_context = save_result["context"]
+
+            # Execute Claude analysis for this batch
+            claude_input = AnalyzeWithClaudeInput(
+                context_dict=PromptContextDict(**updated_context),
+                config_overrides=ClaudeConfigOverrides(**config_overrides.model_dump()) if config_overrides else None,
+                latest_commit=latest_commit
+            )
+
+            claude_result = await workflow.execute_activity(
+                analyze_with_claude_context,
+                args=[claude_input],
+                start_to_close_timeout=timedelta(minutes=15),
+                retry_policy=RetryPolicy(
+                    maximum_attempts=6,
+                    initial_interval=timedelta(seconds=15),
+                    maximum_interval=timedelta(minutes=2),
+                    backoff_coefficient=2.0
+                ),
+            )
+
+            if claude_result.status != "success":
+                raise Exception(f"Map phase failed for batch {batch_idx}: {step_name}")
+
+            batch_result_context = claude_result.context.model_dump()
+            batch_result_key = batch_result_context["result_reference_key"]
+            batch_result_keys.append(batch_result_key)
+
+            logger.info(
+                f"🗺️ Map batch {batch_idx + 1}/{total_batches} complete "
+                f"(result_key: {batch_result_key}, {claude_result.result_length} chars)"
+            )
+
+            # Inter-batch delay to mitigate rate limits
+            if INTER_BATCH_DELAY_SECONDS > 0 and batch_idx < total_batches - 1:
+                logger.info(f"⏳ Rate limit mitigation: waiting {INTER_BATCH_DELAY_SECONDS}s before next batch")
+                await asyncio.sleep(INTER_BATCH_DELAY_SECONDS)
+
+        # === REDUCE PHASE ===
+        logger.info(f"🔄 Reduce phase: synthesizing {total_batches} batch results")
+
+        # Read the reduce prompt template
+        reduce_prompt_file = map_reduce_config["reduce_prompt"]
+        reduce_prompt_result = await workflow.execute_activity(
+            read_prompt_file_activity,
+            args=[prompts_dir, reduce_prompt_file],
+            start_to_close_timeout=timedelta(minutes=2),
+            retry_policy=RetryPolicy(
+                maximum_attempts=2,
+                initial_interval=timedelta(seconds=1),
+                maximum_interval=timedelta(seconds=10),
+            ),
+        )
+
+        if reduce_prompt_result["status"] == "not_found":
+            raise Exception(f"Reduce prompt file not found: {reduce_prompt_file}")
+
+        reduce_prompt_template = reduce_prompt_result["prompt_content"]
+        reduce_prompt_version = reduce_prompt_result.get("prompt_version", "1")
+
+        # Replace total_batches placeholder in reduce prompt
+        reduce_prompt_template = reduce_prompt_template.replace("{total_batches}", str(total_batches))
+
+        # Build context references: batch results + any step context (e.g. hl_overview)
+        reduce_context_keys = list(batch_result_keys)  # All batch results as context
+
+        # Add context from previous steps (e.g. hl_overview)
+        if context_config:
+            for context_step in context_config:
+                if isinstance(context_step, dict) and "val" in context_step:
+                    step_ref = context_step["val"]
+                else:
+                    step_ref = context_step
+                if step_ref and step_ref in step_results:
+                    result_key = step_results[step_ref]
+                    if result_key is not None:
+                        reduce_context_keys.append(result_key)
+
+        reduce_context_dict = {
+            "repo_name": self._repo_name,
+            "step_name": step_name,  # Use the original step name for the final result
+            "prompt_version": reduce_prompt_version,
+            "context_reference_keys": reduce_context_keys
+        }
+
+        # Save reduce prompt (no deps content — batch results are in context_reference_keys)
+        save_result = await workflow.execute_activity(
+            save_prompt_context_activity,
+            args=[reduce_context_dict, reduce_prompt_template, repo_structure, None],
+            start_to_close_timeout=timedelta(minutes=2),
+            retry_policy=RetryPolicy(
+                maximum_attempts=2,
+                initial_interval=timedelta(seconds=1),
+                maximum_interval=timedelta(seconds=10),
+            ),
+        )
+
+        if save_result["status"] != "success":
+            raise Exception(f"Failed to save reduce prompt context for {step_name}")
+
+        updated_context = save_result["context"]
+
+        # Execute Claude synthesis
+        claude_input = AnalyzeWithClaudeInput(
+            context_dict=PromptContextDict(**updated_context),
+            config_overrides=ClaudeConfigOverrides(**config_overrides.model_dump()) if config_overrides else None,
+            latest_commit=latest_commit
+        )
+
+        claude_result = await workflow.execute_activity(
+            analyze_with_claude_context,
+            args=[claude_input],
+            start_to_close_timeout=timedelta(minutes=15),
+            retry_policy=RetryPolicy(
+                maximum_attempts=6,
+                initial_interval=timedelta(seconds=15),
+                maximum_interval=timedelta(minutes=2),
+                backoff_coefficient=2.0
+            ),
+        )
+
+        if claude_result.status != "success":
+            raise Exception(f"Reduce phase failed for step {step_name}")
+
+        result_context = claude_result.context.model_dump()
+        result_key = result_context["result_reference_key"]
+
+        logger.info(
+            f"🔄 Reduce phase complete for {step_name} "
+            f"(result_key: {result_key}, {claude_result.result_length} chars, "
+            f"{total_batches} batches synthesized)"
+        )
+
+        return result_key
+
+    async def _process_analysis_steps(self, processing_order: list, prompts_dir: str, repo_structure: Dict, config_overrides: ConfigOverrides = None, deps_data: dict = None) -> ProcessAnalysisResult:
+        """Process each analysis step using PromptContext for cleaner abstraction.
+
+        Args:
+            processing_order: List of step configurations from base_prompts.json
+            prompts_dir: Directory containing prompt files
+            repo_structure: Repository structure dict
+            config_overrides: Optional Claude config overrides
+            deps_data: Dependencies data dict from _read_and_cache_dependencies,
+                       containing formatted_content, needs_batching, deps_reference_key, etc.
+        """
         if config_overrides is None:
             config_overrides = ConfigOverrides()
+        if deps_data is None:
+            deps_data = {}
+
+        # Extract formatted content for single-pass steps (backward compat)
+        deps_formatted_content = deps_data.get("formatted_content")
 
         self._current_step = 7
         self._step_name = "analyzing"
         self._status = "analyzing"
         self._last_heartbeat = workflow.now()
-        
+
         # Initialize the results collector with base prompts config
         # Load base prompts config for validation
         import json
@@ -281,23 +567,60 @@ class InvestigateSingleRepoWorkflow:
         except Exception as e:
             logger.warning(f"Could not load base prompts config: {e}")
             base_prompts_config = None
-        
+
         results_collector = AnalysisResultsCollector(self._repo_name, base_prompts_config)
-        
+
         # Track step results for building context
         step_results = {}  # Maps step names to result reference keys
         all_result_info = []   # Stores metadata about results
         cached_steps = 0
-        
+
         for step in processing_order:
             step_name = step.get("name", "unknown")
             file_name = step.get("file", "")
             is_required = True
             description = step.get("description", "")
             context_config = step.get("context", None)
-            
+
             logger.info(f"Processing step: {step_name} - {description}")
-            
+
+            # Check if this step needs map-reduce
+            map_reduce_config = step.get("map_reduce")
+            if map_reduce_config and deps_data.get("needs_batching"):
+                logger.info(
+                    f"🗺️ Step {step_name} will use map-reduce "
+                    f"(~{deps_data.get('total_tokens_estimate', 0):,} tokens exceeds batching threshold)"
+                )
+                result_key = await self._process_map_reduce_step(
+                    step, prompts_dir, repo_structure, config_overrides,
+                    deps_data, step_results
+                )
+
+                # Track the result
+                step_results[step_name] = result_key
+                all_result_info.append({
+                    "name": step_name,
+                    "description": description,
+                    "result_key": result_key,
+                    "result_length": 0  # Length unknown from map-reduce
+                })
+                results_collector.track_step(
+                    step_name=step_name,
+                    description=description,
+                    result_key=result_key,
+                    required=is_required,
+                    context_dependencies=[ctx.get("val") for ctx in context_config or [] if isinstance(ctx, dict) and "val" in ctx]
+                )
+                logger.info(f"Step {step_name} completed via map-reduce with result key: {result_key}")
+
+                # Optional inter-step delay
+                if INTER_STEP_DELAY_SECONDS > 0:
+                    logger.info(f"⏳ Rate limit mitigation: waiting {INTER_STEP_DELAY_SECONDS}s before next step")
+                    await asyncio.sleep(INTER_STEP_DELAY_SECONDS)
+                continue
+
+            # --- Standard single-pass flow ---
+
             # Read the prompt file
             prompt_result = await workflow.execute_activity(
                 read_prompt_file_activity,
@@ -309,7 +632,7 @@ class InvestigateSingleRepoWorkflow:
                     maximum_interval=timedelta(seconds=10),
                 ),
             )
-            
+
             if prompt_result["status"] == "not_found":
                 if is_required:
                     logger.error(f"Required prompt file not found: {file_name}")
@@ -317,10 +640,10 @@ class InvestigateSingleRepoWorkflow:
                 else:
                     logger.warning(f"Optional prompt file not found, skipping: {file_name}")
                     continue
-            
+
             prompt_content = prompt_result["prompt_content"]
             prompt_version = prompt_result.get("prompt_version", "1")
-            
+
             # Create PromptContext for this step with proper context references
             context_dict = {
                 "repo_name": self._repo_name,
@@ -328,7 +651,7 @@ class InvestigateSingleRepoWorkflow:
                 "prompt_version": prompt_version,
                 "context_reference_keys": []
             }
-            
+
             # Add context references from previous steps
             if context_config:
                 for context_step in context_config:
@@ -337,7 +660,7 @@ class InvestigateSingleRepoWorkflow:
                         step_ref = context_step["val"]
                     else:
                         step_ref = context_step
-                    
+
                     if step_ref and step_ref in step_results:
                         result_key = step_results[step_ref]
                         # Only add non-None result keys
@@ -345,7 +668,7 @@ class InvestigateSingleRepoWorkflow:
                             context_dict["context_reference_keys"].append(result_key)
                         else:
                             logger.warning(f"Step {step_ref} has None result key, skipping from context")
-            
+
             # Save prompt data to DynamoDB using PromptContext
             logger.info(f"Saving prompt data for step: {step_name}")
             save_result = await workflow.execute_activity(
@@ -358,25 +681,25 @@ class InvestigateSingleRepoWorkflow:
                     maximum_interval=timedelta(seconds=10),
                 ),
             )
-            
+
             if save_result["status"] != "success":
                 raise Exception(f"Failed to save prompt context for step {step_name}")
-            
+
             # Get updated context with data reference key
             updated_context = save_result["context"]
-            
+
             # Execute Claude analysis using PromptContext with prompt-level caching
             logger.info(f"Calling Claude for step: {step_name}")
             # Get latest_commit from workflow state (passed from parent)
             latest_commit = getattr(self, '_latest_commit', None)
-            
+
             # Create Pydantic input model
             claude_input = AnalyzeWithClaudeInput(
                 context_dict=PromptContextDict(**updated_context),
                 config_overrides=ClaudeConfigOverrides(**config_overrides.model_dump()) if config_overrides else None,
                 latest_commit=latest_commit
             )
-            
+
             claude_result = await workflow.execute_activity(
                 analyze_with_claude_context,
                 args=[claude_input],
@@ -388,19 +711,19 @@ class InvestigateSingleRepoWorkflow:
                     backoff_coefficient=2.0
                 ),
             )
-            
+
             if claude_result.status != "success":
                 raise Exception(f"Claude analysis failed for step {step_name}")
-            
+
             # Log if result was from cache
             if claude_result.cached:
                 logger.info(f"✅ Used cached result for step {step_name}: {claude_result.cache_reason or 'Unknown reason'}")
                 cached_steps += 1
-            
+
             # Get the result context with result key
             result_context = claude_result.context.model_dump()
             result_key = result_context["result_reference_key"]
-            
+
             # Store result key for future context use
             step_results[step_name] = result_key
             all_result_info.append({
@@ -409,7 +732,7 @@ class InvestigateSingleRepoWorkflow:
                 "result_key": result_key,
                 "result_length": claude_result.result_length
             })
-            
+
             # Track the step in the results collector
             results_collector.track_step(
                 step_name=step_name,
@@ -418,7 +741,7 @@ class InvestigateSingleRepoWorkflow:
                 required=is_required,
                 context_dependencies=[ctx.get("val") for ctx in context_config or [] if isinstance(ctx, dict) and "val" in ctx]
             )
-            
+
             logger.info(f"Step {step_name} completed with result key: {result_key}")
 
             # Optional inter-step delay to mitigate API rate limits
@@ -728,16 +1051,22 @@ class InvestigateSingleRepoWorkflow:
         # Step 3.5: Read and cache dependencies
         deps_result = await self._read_and_cache_dependencies(repo_path)
         deps_reference_key = deps_result.get("deps_reference_key")
-        deps_formatted_content = deps_result.get("formatted_content")
-        
+
+        if deps_result.get("needs_batching"):
+            logger.info(
+                f"📦 Dependencies will use map-reduce batching "
+                f"(~{deps_result.get('total_tokens_estimate', 0):,} estimated tokens)"
+            )
+
         # Step 4: Reuse prompts configuration (already loaded for cache check)
         logger.info(f"📝 WORKFLOW: Reusing prompts configuration loaded earlier")
         prompts_result = early_prompts_result  # Reuse the configuration loaded before cache check
         prompts_dir = prompts_result.prompts_dir
         processing_order = prompts_result.processing_order
-        
+
         # Step 5: Process each analysis step as separate activities
-        analysis_result = await self._process_analysis_steps(processing_order, prompts_dir, repo_structure, config_overrides, deps_formatted_content)
+        # Pass full deps_result dict so map-reduce can access needs_batching, deps_reference_key, etc.
+        analysis_result = await self._process_analysis_steps(processing_order, prompts_dir, repo_structure, config_overrides, deps_data=deps_result)
         step_results = analysis_result.step_results
         all_results = analysis_result.all_results
         

--- a/src/workflows/investigate_single_repo_workflow.py
+++ b/src/workflows/investigate_single_repo_workflow.py
@@ -124,7 +124,7 @@ class InvestigateSingleRepoWorkflow:
         clone_result = await workflow.execute_activity(
             clone_repository_activity,
             args=[repo_url, repo_name],
-            start_to_close_timeout=timedelta(minutes=3),
+            start_to_close_timeout=timedelta(minutes=10),
             retry_policy=RetryPolicy(
                 maximum_attempts=3,
                 initial_interval=timedelta(seconds=5),
@@ -260,7 +260,9 @@ class InvestigateSingleRepoWorkflow:
 
         return {
             "deps_reference_key": deps_reference_key,
-            "formatted_content": deps_data["formatted_content"]
+            "formatted_content": deps_data["formatted_content"],
+            "needs_batching": deps_data.get("needs_batching", False),
+            "total_tokens_estimate": deps_data.get("total_tokens_estimate", 0),
         }
 
     async def _process_map_reduce_step(self, step: dict, prompts_dir: str,


### PR DESCRIPTION
## Summary
- Large repos (e.g. quarkus with 2,215 dep files / 13.4MB) were losing ~96% of data due to truncation
- Adds automatic map-reduce: splits dependencies into batches (~100K tokens each), analyzes each batch independently, then synthesizes results
- Batching is auto-detected at runtime when total tokens exceed MIN_TOKENS_FOR_BATCHING (50K)
- Truncation remains as a safety-net fallback for edge cases
- Batch data stored in DynamoDB with 120-min TTL
- New prompt templates: dependencies_batch.md (map) and dependencies_reduce.md (reduce)

Depends on #24

## Test plan
- [ ] Run investigation on a large repo (e.g. quarkus) and verify map-reduce triggers
- [ ] Verify batch results are synthesized into a coherent dependency analysis
- [ ] Verify small repos still use the standard single-pass analysis
- [ ] Verify inter-batch rate limiting (INTER_BATCH_DELAY_SECONDS) is respected

Generated with [Claude Code](https://claude.com/claude-code)